### PR TITLE
readme: add working directory running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Check out the Up and Running section to get it started
 $ brew install glfw glew glm 
 ```
 
+Also you will have to change the `working directory` in `Xcode`, like this:
+
+- First go to `Product` > `Scheme` > `Edit Scheme...`
+
+<img width="940" alt="how-to-find-product-edit-scheme" src="https://user-images.githubusercontent.com/15306309/72669950-9e6f3080-3a16-11ea-8dfd-22f98b6a8722.png">
+
+- Then go to `Options` and change the `Working Directory` to a folder like this:
+
+```
+/where/youve/cloned/opengl-labs-cpp/opengl-labs-cpp
+```
+
+Which is where the project code is (`.h`, `.hpp` and `cpp` files).
+
+<img width="897" alt="how-to-edit-working-directory" src="https://user-images.githubusercontent.com/15306309/72669951-9e6f3080-3a16-11ea-83dd-da116b5cdb06.png">
+
 **Linux | Windows**
 ```
 T.B.D.


### PR DESCRIPTION
Hey! So I've tried running the project, and to actually make it work I had to change the working directory, since the one commited is your computer's directory (`/Users/iobruno/Vault/opengl-labs-cpp/opengl-labs-cpp`), which is defined here: https://github.com/iobruno/opengl-labs-cpp/blob/master/opengl-labs-cpp.xcodeproj/xcshareddata/xcschemes/opengl-labs-cpp.xcscheme#L50.

So I've added to the `README.md` instructions on how to edit this directory to make the Shader files be able to be loaded 🙂 

Honestly I would like that this path to be relative, but I don't know much about `Xcode` to do that 😅 
So at least this is how you can run on another computer.